### PR TITLE
Add SwiftUI visit tracking app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# track_visit_ios
+# Track Visit iOS App
+
+This project demonstrates a minimal SwiftUI application that uses the MVVM + Coordinator architecture pattern to track user visits using Core Location.
+
+## Features
+- Uses `CLLocationManager` visit monitoring (`locationManager(_:didVisit:)`).
+- Displays a list of visits with entry/exit times, coordinates, and duration.
+
+## Structure
+- `TrackVisitAppApp.swift` – App entry point.
+- `Coordinators/AppCoordinator.swift` – Handles starting the main view.
+- `ViewModels/VisitsViewModel.swift` – Manages visit data and interacts with `CLLocationManager`.
+- `Views/VisitsView.swift` – SwiftUI view that shows logged visits.
+
+## Running the App
+Open the `TrackVisitApp` folder in Xcode and run on a real device to collect visit data.
+Make sure to grant Always Location permission when prompted.

--- a/TrackVisitApp/Coordinators/AppCoordinator.swift
+++ b/TrackVisitApp/Coordinators/AppCoordinator.swift
@@ -1,0 +1,9 @@
+import SwiftUI
+
+final class AppCoordinator: ObservableObject {
+    @Published var visitsViewModel = VisitsViewModel()
+
+    func rootView() -> some View {
+        VisitsView(viewModel: visitsViewModel)
+    }
+}

--- a/TrackVisitApp/Models/VisitEntry.swift
+++ b/TrackVisitApp/Models/VisitEntry.swift
@@ -1,0 +1,13 @@
+import Foundation
+import CoreLocation
+
+struct VisitEntry: Identifiable {
+    let id = UUID()
+    let arrivalDate: Date
+    let departureDate: Date
+    let coordinate: CLLocationCoordinate2D
+
+    var duration: TimeInterval {
+        departureDate.timeIntervalSince(arrivalDate)
+    }
+}

--- a/TrackVisitApp/TrackVisitAppApp.swift
+++ b/TrackVisitApp/TrackVisitAppApp.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+@main
+struct TrackVisitAppApp: App {
+    @StateObject private var coordinator = AppCoordinator()
+
+    var body: some Scene {
+        WindowGroup {
+            coordinator.rootView()
+        }
+    }
+}

--- a/TrackVisitApp/ViewModels/VisitsViewModel.swift
+++ b/TrackVisitApp/ViewModels/VisitsViewModel.swift
@@ -1,0 +1,28 @@
+import Foundation
+import Combine
+import CoreLocation
+
+final class VisitsViewModel: NSObject, ObservableObject {
+    @Published var visits: [VisitEntry] = []
+    private let locationManager = CLLocationManager()
+
+    override init() {
+        super.init()
+        locationManager.delegate = self
+        locationManager.requestAlwaysAuthorization()
+        locationManager.startMonitoringVisits()
+    }
+}
+
+extension VisitsViewModel: CLLocationManagerDelegate {
+    func locationManager(_ manager: CLLocationManager, didVisit visit: CLVisit) {
+        let entry = VisitEntry(
+            arrivalDate: visit.arrivalDate,
+            departureDate: visit.departureDate,
+            coordinate: visit.coordinate
+        )
+        DispatchQueue.main.async {
+            self.visits.append(entry)
+        }
+    }
+}

--- a/TrackVisitApp/Views/VisitsView.swift
+++ b/TrackVisitApp/Views/VisitsView.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+
+struct VisitsView: View {
+    @ObservedObject var viewModel: VisitsViewModel
+
+    var body: some View {
+        NavigationView {
+            List(viewModel.visits) { visit in
+                VStack(alignment: .leading) {
+                    Text("Arrival: \(visit.arrivalDate)")
+                    Text("Departure: \(visit.departureDate)")
+                    Text(String(format: "Lat: %.4f, Lon: %.4f", visit.coordinate.latitude, visit.coordinate.longitude))
+                    Text("Duration: \(visit.duration) seconds")
+                }
+            }
+            .navigationTitle("Visits")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a simple SwiftUI project stub
- log `CLVisit` objects through a view model
- show visits in a list using MVVM-Coordinator pattern
- update README with build instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_687a43b795bc83309fad05b6770cd582