### PR TITLE
Fix escaping autoclosure error

### DIFF
--- a/Track Visit/Track Visit/Track_VisitApp.swift
+++ b/Track Visit/Track Visit/Track_VisitApp.swift
@@ -11,23 +11,23 @@ import CoreLocation
 
 @main
 struct Track_VisitApp: App {
-    var sharedModelContainer: ModelContainer = {
+    let sharedModelContainer: ModelContainer
+
+    @StateObject private var visitTracker: VisitTracker
+
+    init() {
         let schema = Schema([
             Item.self,
         ])
         let modelConfiguration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: false)
 
         do {
-            return try ModelContainer(for: schema, configurations: [modelConfiguration])
+            let container = try ModelContainer(for: schema, configurations: [modelConfiguration])
+            self.sharedModelContainer = container
+            _visitTracker = StateObject(wrappedValue: VisitTracker(context: container.mainContext))
         } catch {
             fatalError("Could not create ModelContainer: \(error)")
         }
-    }()
-
-    @StateObject private var visitTracker: VisitTracker
-
-    init() {
-        _visitTracker = StateObject(wrappedValue: VisitTracker(context: sharedModelContainer.mainContext))
     }
 
     var body: some Scene {


### PR DESCRIPTION
## Summary
- initialize the `ModelContainer` inside `init()` so that it doesn't capture `self` in an escaping closure
- update initialization of `visitTracker`

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_b_687e0a33716c83309557b00006049997