### PR TITLE
Enable background visit tracking

### DIFF
--- a/Track Visit/Track Visit/VisitTracker.swift
+++ b/Track Visit/Track Visit/VisitTracker.swift
@@ -12,6 +12,9 @@ final class VisitTracker: NSObject, ObservableObject, CLLocationManagerDelegate 
         super.init()
         self.locationManager.delegate = self
         self.locationManager.requestAlwaysAuthorization()
+        // Enable location updates while the app is in the background so that
+        // visit events are delivered even when the UI is not active.
+        self.locationManager.allowsBackgroundLocationUpdates = true
         self.locationManager.startMonitoringVisits()
     }
 


### PR DESCRIPTION
## Summary
- allow CLLocationManager background updates so visits are recorded when the app isn't active

## Testing
- `swift --version`
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_687e119ab2ac8330befa3b1046500973